### PR TITLE
fix issue with redirect_uri not taken into account

### DIFF
--- a/lib/hubic.rb
+++ b/lib/hubic.rb
@@ -163,7 +163,7 @@ class Hubic
         r = @conn.get '/oauth/auth', {
             :client_id     => @client_id,
             :response_type => 'code',
-            :redirect_uri  => 'http://localhost/',
+            :redirect_uri  => @redirect_uri,
             :scope         => 'account.r,usage.r,links.drw,credentials.r',
             :state         => 'random'
         }
@@ -210,7 +210,7 @@ class Hubic
     def get_access_token(code)
         r = @conn.post '/oauth/token', {
             :code          => code,
-            :redirect_uri  => 'http://localhost/',
+            :redirect_uri  => @redirect_uri,
             :grant_type    => 'authorization_code',
             :client_id     => @client_id,
             :client_secret => @client_secret


### PR DESCRIPTION
The redirect_uri is had coded to http://localhost/ in both Hbic::get_request_code and Hubic::get_access_token.
If the redirect URI of the application is different, then the authentication is failing.